### PR TITLE
fix: prevent burning frens if not enough frens

### DIFF
--- a/apps/dapp/src/components/Balances.tsx
+++ b/apps/dapp/src/components/Balances.tsx
@@ -13,7 +13,7 @@ export const Balance = ({
   address: string;
   token: TOKEN_ID;
 }) => {
-  const { free, decimals } = useBalance(address, token);
+  const { free, decimals } = useBalance(token, address);
   return (
     <div className=" text-base flex gap-1">
       {token === "FREN" && <FrenCoin className="inline h-6 w-6" />}

--- a/apps/dapp/src/lib/tokensToPlanck.ts
+++ b/apps/dapp/src/lib/tokensToPlanck.ts
@@ -1,0 +1,12 @@
+import { BN } from "@polkadot/util";
+
+type BNish = string | number | BN | Uint8Array | number[] | Buffer;
+
+export const tokensToPlanck = (tokens: BNish, decimals: BNish) => {
+  const tokenAmount = new BN(tokens);
+  const tokenDecimals = new BN(decimals);
+  const base = new BN("10");
+  const planck = tokenAmount.mul(base.pow(tokenDecimals));
+
+  return planck;
+};

--- a/apps/dapp/src/lib/useBalance.ts
+++ b/apps/dapp/src/lib/useBalance.ts
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { useEffect } from "react";
 import { useMemo } from "react";
 
-export const useBalance = (address: string, tokenId: TOKEN_ID) => {
+export const useBalance = (tokenId: TOKEN_ID, address?: string) => {
   const { blockNumber } = useGmTime();
   const api = useApi();
   const [free, setFree] = useState<string>();
@@ -15,7 +15,12 @@ export const useBalance = (address: string, tokenId: TOKEN_ID) => {
   const decimals = useMemo(() => TOKEN_DECIMALS[tokenId], [tokenId]);
 
   useEffect(() => {
-    if (!api) return;
+    // clear if address changes
+    setFree(undefined);
+  }, [address]);
+
+  useEffect(() => {
+    if (!api || !address) return;
 
     if (tokenId === NATIVE_TOKEN)
       api.query.system.account(address).then((accountInfo) => {


### PR DESCRIPTION
if account doesn't have enough frens and clicks the burn button, it will display a "not enough frens" error instead of submitting the extrinsic