### PR TITLE
feat: use fastest RPC node

### DIFF
--- a/apps/dapp/.env
+++ b/apps/dapp/.env
@@ -1,6 +1,6 @@
 VITE_APP_NAME=GM - Say it back!
 
 # overriden on prod environment
-VITE_WS_RPC_URL=wss://ws.gm.bldnodes.org
+VITE_WS_RPC_URLS=wss://ws.gm.bldnodes.org,wss://ws-node-gm.terrabiodao.org,wss://kusama.gmordie.com
 
 VITE_SUBSQUID_URL=https://squid.subsquid.io/gmordie-frontend/v/v1/graphql

--- a/apps/dapp/src/lib/getApi.ts
+++ b/apps/dapp/src/lib/getApi.ts
@@ -1,11 +1,20 @@
-import { WS_RPC_URL } from "./settings";
+import { WS_RPC_URLS } from "./settings";
 import { types } from "@open-web3/orml-type-definitions";
 import { ApiPromise, WsProvider } from "@polkadot/api";
 
+const TIMEOUT = 10_000;
+
 export const getApi = async () => {
-  const wsProvider = new WsProvider(WS_RPC_URL);
-  const api = await ApiPromise.create({ provider: wsProvider });
-  // need the OrmlAccountData type
+  // Promise.any returns the fastest WsProvider to be ready
+  // This should spread the load on all available nodes
+  const provider = await Promise.any(
+    WS_RPC_URLS.map((url) => new WsProvider(url, TIMEOUT)).map((p) => p.isReady)
+  );
+
+  const api = await ApiPromise.create({ provider });
+
+  // register ORML types
   api.registerTypes(types);
+
   return api;
 };

--- a/apps/dapp/src/lib/settings.ts
+++ b/apps/dapp/src/lib/settings.ts
@@ -1,3 +1,7 @@
-export const WS_RPC_URL = import.meta.env.VITE_WS_RPC_URL;
-export const APP_NAME = import.meta.env.VITE_APP_NAME;
-export const SUBSQUID_URL = import.meta.env.VITE_SUBSQUID_URL;
+export const APP_NAME: string = import.meta.env.VITE_APP_NAME;
+
+export const SUBSQUID_URL: string = import.meta.env.VITE_SUBSQUID_URL;
+
+// RPC urls are separated by commas
+const rpcUrls: string = import.meta.env.VITE_WS_RPC_URLS;
+export const WS_RPC_URLS = rpcUrls.split(",").map((str) => str.trim());


### PR DESCRIPTION
Picks the fastest WsProvider to be ready.
This should spread the load on all healthy nodes