### PR TITLE
liga from substrate connect will be happy

### DIFF
--- a/apps/dapp/src/chainSpecs/gm.json
+++ b/apps/dapp/src/chainSpecs/gm.json
@@ -1,5 +1,5 @@
 {
-  "name": "GM Parachain",
+  "name": "GM",
   "id": "its_a_lifestyle",
   "chainType": "Live",
   "bootNodes": [


### PR DESCRIPTION
liga standards does not support spaces.

this will make the substrate connect extention being able to lookup the gm icon

![image](https://user-images.githubusercontent.com/2903505/196569638-5957f6a1-90d8-4244-aafc-ac8d2ae2fe20.png)
